### PR TITLE
Introduce e2e tests with playwright.

### DIFF
--- a/e2e-tests/.gitignore
+++ b/e2e-tests/.gitignore
@@ -1,0 +1,7 @@
+
+# Playwright
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/e2e-tests/index.php
+++ b/e2e-tests/index.php
@@ -1,0 +1,38 @@
+<?php
+
+require_once __DIR__ . '/../tests/bootstrap.php';
+
+use HelloCoop\Config\HelloConfigBuilder;
+use HelloCoop\HelloClient;
+
+
+define('API_ROUTE', '/api/hellocoop');
+
+$builder = new HelloConfigBuilder();
+$config = $builder
+    ->setApiRoute('/api/hellocoop')
+    ->setAuthApiRoute('/api/hellocoop?op=auth')
+    ->setLoginApiRoute('/api/hellocoop?op=login')
+    ->setLogoutApiRoute('/api/hellocoop?op=logout')
+    ->setSameSiteStrict(false)
+    ->setClientId('000000-0000-0000-0000-000000000000')
+    ->setRedirectURI('http://localhost:8000/api/hellocoop')
+    ->setSecret('66c71f55568f7b0c3b30cb6a8df9975b5125000caa775240b2e76eb96c43715e')
+    ->setHelloWallet('http://127.0.0.1:3333')
+    ->setScope(['openid', 'profile', 'email'])
+    ->build();
+
+// Step 3: Create an instance of HelloClient
+$helloClient = new HelloClient($config);
+
+$requestUri = $_SERVER['REQUEST_URI'];
+$parsedUrl = parse_url($requestUri); // Extract the path from the request URI, ignoring query parameters
+$requestPath = $parsedUrl['path'] ?? '';
+
+// Step 4: Route Hellō API requests
+if ($requestPath === API_ROUTE) {
+    $helloClient->route(); // Handle the routing of the API request
+}
+
+header('Content-Type: application/json');
+print json_encode($helloClient->getAuth());

--- a/e2e-tests/package-lock.json
+++ b/e2e-tests/package-lock.json
@@ -1,0 +1,97 @@
+{
+  "name": "e2e-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "e2e-tests",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.54.2",
+        "@types/node": "^24.2.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "e2e-tests",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {},
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@playwright/test": "^1.54.2",
+    "@types/node": "^24.2.1"
+  }
+}

--- a/e2e-tests/php.spec.ts
+++ b/e2e-tests/php.spec.ts
@@ -1,0 +1,289 @@
+const APP_HOME = 'http://127.0.0.1:8000/'
+const MOCKIN = 'http://127.0.0.1:3333/'
+const APP_API = APP_HOME + 'api/hellocoop'
+
+import { test, expect } from '@playwright/test'
+
+const config = {
+    client_id: '000000-0000-0000-0000-000000000000',
+    // sameSiteStrict: true,
+}
+const loggedOut = { isLoggedIn: false }
+const loggedIn = {
+    isLoggedIn: true,
+    sub: '00000000-0000-0000-0000-00000000',
+    name: 'John Smith',
+    email: 'john.smith@example.com',
+    picture: 'https://pictures.hello.coop/mock/portrait-of-john-smith.jpeg',
+    email_verified: true,
+}
+const usrDanBrown = {
+    isLoggedIn: true,
+    sub: 'sub_wdfp66OC0Me43YW9q6sisnP6_h2q',
+    name: 'Dan Brown',
+    email: 'dan.brown@example.net',
+    picture: 'https://pictures.hello.coop/mock/john-smith-facebook.jpeg',
+    email_verified: true,
+}
+const usrLewisCarroll = {
+    isLoggedIn: true,
+    sub: 'sub_PrHrJvaaszcdyltTt52v3UcH_dbf',
+    name: 'Lewis Carroll',
+    picture: 'https://pictures.hello.coop/mock/john-smith-yahoo.jpeg',
+    email: 'lewis.carroll@example.org',
+    email_verified: true,
+}
+
+/*
+* used for debugging
+*
+const trace = (page) => {
+    page.on('request', async request => {
+        console.log('Request:', request.method(), request.url());
+        console.log('\theaders:', request.headers());
+      });
+
+    page.on('response', async response => {
+        console.log('Response:', response.status(), response.url());
+        console.log('\tresponse headers:', response.headers());
+    });
+
+    page.on('requestfailed', request => {
+        console.log('Request failed:', request.method(), request.url(), request?.failure()?.errorText);
+        console.log('\theaders:', request.headers());
+    });
+}
+*/
+
+test.describe(`Testing ${APP_HOME}`, () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto(APP_API + '?op=logout')
+    })
+    test('logged out', async ({ page }) => {
+        await page.goto(APP_HOME)
+        const body = await page.textContent('body')
+        try {
+            const json = JSON.parse(body as string)
+            delete json.iat
+            expect(json).toEqual(loggedOut)
+        } catch (e) {
+            expect(e).toBeNull()
+        }
+    })
+    test('logged in', async ({ page }) => {
+        await page.goto(APP_API + '?op=login')
+        const body = await page.textContent('body')
+        try {
+            const json = JSON.parse(body as string)
+            delete json.iat
+            expect(json).toEqual(loggedIn)
+        } catch (e) {
+            expect(e).toBeNull()
+        }
+    })
+    test('auth', async ({ page }) => {
+        // log in first
+        await page.goto(APP_API + '?op=login')
+
+        // check auth
+        await page.goto(APP_API + '?op=auth')
+        const body = await page.textContent('body')
+        try {
+            const json = JSON.parse(body as string)
+            delete json.iat
+            expect(json).toEqual(loggedIn)
+        } catch (e) {
+            expect(e).toBeNull()
+        }
+    })
+    test('IdP initiated login w/ GET login_hint', async ({ page }) => {
+        const data = new URLSearchParams({
+            op: 'login',
+            login_hint: 'dan.brown@example.net',
+        })
+        await page.goto(APP_API + '?' + data.toString())
+        const body = await page.textContent('body')
+        expect(body).toBeDefined
+        const json = JSON.parse(body as string)
+        expect(json).toBeDefined
+        delete json.iat
+        expect(json).toEqual(usrDanBrown)
+    })
+    test('IdP initiated login w/ POST login_hint', async ({ page }) => {
+        const data = new URLSearchParams({
+            op: 'login',
+            login_hint: 'dan.brown@example.net',
+        })
+        await page.goto(APP_HOME + 'post-test?' + data.toString())
+        const body = await page.textContent('body')
+        expect(body).toBeDefined
+        const json = JSON.parse(body as string)
+        expect(json).toBeDefined
+        delete json.iat
+        expect(json).toEqual(usrDanBrown)
+    })
+    test('IdP initiated login w/ GET login_hint & iss', async ({ page }) => {
+        const data = new URLSearchParams({
+            op: 'login',
+            login_hint: 'dan.brown@example.net',
+            iss: 'https://issuer.hello.coop',
+        })
+        await page.goto(APP_API + '?' + data.toString())
+        const body = await page.textContent('body')
+        expect(body).toBeDefined
+        const json = JSON.parse(body as string)
+        expect(json).toBeDefined
+        delete json.iat
+        expect(json).toEqual(usrDanBrown)
+    })
+    test('IdP initiated login w/ POST login_hint & iss', async ({ page }) => {
+        const data = new URLSearchParams({
+            op: 'login',
+            login_hint: 'dan.brown@example.net',
+            iss: 'https://issuer.hello.coop',
+        })
+        await page.goto(APP_HOME + 'post-test?' + data.toString())
+        const body = await page.textContent('body')
+        expect(body).toBeDefined
+        const json = JSON.parse(body as string)
+        expect(json).toBeDefined
+        delete json.iat
+        expect(json).toEqual(usrDanBrown)
+    })
+    test('IdP initiated login w/ GET login_hint & domain_hint', async ({
+        page,
+    }) => {
+        const data = new URLSearchParams({
+            op: 'login',
+            login_hint: 'dan.brown@example.net',
+            domain_hint: 'example.net',
+        })
+        await page.goto(APP_API + '?' + data.toString())
+        const body = await page.textContent('body')
+        expect(body).toBeDefined
+        const json = JSON.parse(body as string)
+        expect(json).toBeDefined
+        delete json.iat
+        expect(json).toEqual(usrDanBrown)
+    })
+    test('domain_hint', async ({ page }) => {
+        const data = new URLSearchParams({
+            op: 'login',
+            domain_hint: 'example.org',
+        })
+        await page.goto(APP_API + '?' + data.toString())
+        const body = await page.textContent('body')
+        expect(body).toBeDefined
+        const json = JSON.parse(body as string)
+        expect(json).toBeDefined
+        delete json.iat
+        expect(json).toEqual(usrLewisCarroll)
+    })
+    test('IdP initiated login w/ GET domain_hint', async ({ page }) => {
+        const data = new URLSearchParams({
+            domain_hint: 'example.org',
+        })
+        await page.goto(APP_API + '?' + data.toString())
+        const body = await page.textContent('body')
+        expect(body).toBeDefined
+        const json = JSON.parse(body as string)
+        expect(json).toBeDefined
+        delete json.iat
+        expect(json).toEqual(usrLewisCarroll)
+    })
+    test('IdP initiated login w/ POST domain_hint', async ({ page }) => {
+        const data = new URLSearchParams({
+            op: 'login',
+            domain_hint: 'example.org',
+        })
+        await page.goto(APP_HOME + 'post-test?' + data.toString())
+        const body = await page.textContent('body')
+        expect(body).toBeDefined
+        const json = JSON.parse(body as string)
+        expect(json).toBeDefined
+        delete json.iat
+        expect(json).toEqual(usrLewisCarroll)
+    })
+    test('IdP initiated login w/ GET domain_hint & iss', async ({ page }) => {
+        const data = new URLSearchParams({
+            op: 'login',
+            domain_hint: 'example.org',
+            iss: 'https://issuer.hello.coop',
+        })
+        await page.goto(APP_API + '?' + data.toString())
+        const body = await page.textContent('body')
+        expect(body).toBeDefined
+        const json = JSON.parse(body as string)
+        expect(json).toBeDefined
+        delete json.iat
+        expect(json).toEqual(usrLewisCarroll)
+    })
+    test('IdP initiated login w/ POST domain_hint & iss', async ({ page }) => {
+        const data = new URLSearchParams({
+            op: 'login',
+            domain_hint: 'example.org',
+            iss: 'https://issuer.hello.coop',
+        })
+        await page.goto(APP_HOME + 'post-test?' + data.toString())
+        const body = await page.textContent('body')
+        expect(body).toBeDefined
+        const json = JSON.parse(body as string)
+        expect(json).toBeDefined
+        delete json.iat
+        expect(json).toEqual(usrLewisCarroll)
+    })
+    test('invite', async ({ page }) => {
+        // log in first
+        await page.goto(APP_API + '?op=login')
+
+        // invite
+        const appName = 'Test'
+        const data = new URLSearchParams({
+            op: 'invite',
+            app_name: appName,
+        })
+        await page.goto(APP_API + '?' + data.toString())
+        const url = page.url()
+        const inviteReqUrl = new URL(url)
+        const inviteReqUrlParams = new URLSearchParams(inviteReqUrl.search)
+        const inviter = inviteReqUrlParams.get('inviter')
+        expect(inviter).toEqual(loggedIn.sub)
+        const client_id = inviteReqUrlParams.get('client_id')
+        expect(client_id).toEqual(config.client_id)
+        const initiate_login_uri = inviteReqUrlParams.get('initiate_login_uri')
+        expect(initiate_login_uri).toEqual(APP_API)
+        const app_name = inviteReqUrlParams.get('app_name')
+        expect(app_name).toEqual(appName)
+        const prompt = inviteReqUrlParams.get('prompt')
+        expect(prompt).toEqual(
+            `${loggedIn.name} has invited you to join ${appName}`,
+        )
+        const return_uri = inviteReqUrlParams.get('return_uri')
+        expect(return_uri).toEqual(APP_HOME)
+    })
+    test('should get metadata', async ({ page }) => {
+        const commandTokenRes = await page.request.get(
+            MOCKIN + 'command/mock?client_id=' + config.client_id,
+        )
+        const { command_token } = await commandTokenRes.json()
+        expect(command_token).toBeDefined
+        const data = new URLSearchParams({ command_token })
+        await page.goto(APP_HOME + 'post-test?' + data.toString())
+        const body = await page.textContent('body')
+        expect(body).toBeDefined
+        const metadata = JSON.parse(body as string)
+        expect(metadata).toBeDefined
+        expect(metadata.context).toBeDefined()
+        // expect(metadata.context.package_name).toBe();
+        expect(metadata.context.package_version).toBeDefined()
+        // expect(metadata.context.package_version).toBe('0.0.1');
+        expect(metadata.context.iss).toBeDefined()
+        expect(metadata.commands_uri).toBeDefined()
+        expect(metadata.commands_supported).toBeDefined()
+        expect(metadata.commands_supported).toEqual(['metadata'])
+        expect(metadata.commands_ttl).toBeDefined()
+        expect(metadata.commands_ttl).toEqual(0)
+        expect(metadata.client_id).toBeDefined()
+        expect(metadata.client_id).toEqual(config.client_id)
+    })
+})

--- a/e2e-tests/playwright.config.js
+++ b/e2e-tests/playwright.config.js
@@ -1,0 +1,62 @@
+// @ts-check
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+export default defineConfig({
+  testDir: './.',
+  /* Run tests in files in parallel */
+  fullyParallel: false,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'http://localhost:8000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: [
+    {
+       command: 'php -S localhost:8000',
+       url: 'http://127.0.0.1:8000',
+       // stdout: 'pipe',
+       timeout: 10000,
+       reuseExistingServer: !process.env.CI,
+    },
+    {
+       command: 'npx @hellocoop/mockin',
+       url: 'http://127.0.0.1:3333/version',
+       // stdout: 'pipe',
+       timeout: 10000,
+       reuseExistingServer: !process.env.CI,
+    },
+  ],
+});
+


### PR DESCRIPTION
Introduce e2e tests using playwright.

The playwright spec is taken directly from the [express](https://github.com/hellocoop/packages-js/tree/main/express) implementation in `packages.js`