### PR TITLE
Refactor HelloResponseInterface to support framework-specific response objects

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -187,14 +187,14 @@ jobs:
       - name: Install dependencies
         run: cd e2e-tests && npm ci && npx playwright install --with-deps
 
-      # # Run the e2e tests
-      # - name: Run Playwright tests
-      #   run: cd e2e-tests && npx playwright test
+      # Run the e2e tests
+      - name: Run Playwright tests
+        run: cd e2e-tests && npx playwright test
 
-      # # Upload report after each run
-      # - uses: actions/upload-artifact@v4
-      #   if: ${{ !cancelled() }}
-      #   with:
-      #     name: playwright-report
-      #     path: ./e2e-tests/playwright-report/
-      #     retention-days: 30
+      # Upload report after each run
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: ./e2e-tests/playwright-report/
+          retention-days: 30

--- a/e2e-tests/index.php
+++ b/e2e-tests/index.php
@@ -22,17 +22,19 @@ $config = $builder
     ->setScope(['openid', 'profile', 'email'])
     ->build();
 
-// Step 3: Create an instance of HelloClient
+// Create an instance of HelloClient
 $helloClient = new HelloClient($config);
 
 $requestUri = $_SERVER['REQUEST_URI'];
-$parsedUrl = parse_url($requestUri); // Extract the path from the request URI, ignoring query parameters
+// Extract the path from the request URI, ignoring query parameters
+$parsedUrl = parse_url($requestUri);
 $requestPath = $parsedUrl['path'] ?? '';
 
-// Step 4: Route Hellō API requests
+// Route Hellō API requests
 if ($requestPath === API_ROUTE) {
-    $helloClient->route(); // Handle the routing of the API request
+    // Handle the routing of the API request
+    print $helloClient->route();
+} else {
+    header('Content-Type: application/json');
+    print json_encode($helloClient->getAuth());
 }
-
-header('Content-Type: application/json');
-print json_encode($helloClient->getAuth());

--- a/e2e-tests/php.spec.ts
+++ b/e2e-tests/php.spec.ts
@@ -1,4 +1,4 @@
-const APP_HOME = 'http://127.0.0.1:8000/'
+const APP_HOME = 'http://localhost:8000/'
 const MOCKIN = 'http://127.0.0.1:3333/'
 const APP_API = APP_HOME + 'api/hellocoop'
 

--- a/e2e-tests/php.spec.ts
+++ b/e2e-tests/php.spec.ts
@@ -1,5 +1,5 @@
 const APP_HOME = 'http://localhost:8000/'
-const MOCKIN = 'http://127.0.0.1:3333/'
+const MOCKIN = 'http://localhost:3333/'
 
 const APP_API = APP_HOME + 'api/hellocoop'
 

--- a/e2e-tests/playwright.config.js
+++ b/e2e-tests/playwright.config.js
@@ -45,7 +45,7 @@ export default defineConfig({
   webServer: [
     {
        command: 'php -S localhost:8000',
-       url: 'http://127.0.0.1:8000',
+       url: 'http://localhost:8000',
        // stdout: 'pipe',
        timeout: 10000,
        reuseExistingServer: !process.env.CI,

--- a/src/Handler/Command.php
+++ b/src/Handler/Command.php
@@ -145,7 +145,7 @@ class Command
         /** @var string $iss */
         $iss = $claims['iss'];
         /** @var string $sub */
-        $sub = $claims['sub'];
+        $sub = $claims['sub'] ?? '';
         /** @var string|null $tenant */
         $tenant = isset($claims['tenant']) ? $claims['tenant'] : null;
         /** @var array<string>|null $groups */

--- a/src/Handler/Invite.php
+++ b/src/Handler/Invite.php
@@ -37,6 +37,26 @@ final class Invite
     }
 
     /**
+     * Build origin like "https://example.com[:port]" from a URL.
+     * Falls back to empty string if not derivable.
+     */
+    private function buildOrigin(?string $url): string
+    {
+        if ($url === null || $url === '') {
+            return '';
+        }
+        $parts = parse_url($url);
+        if ($parts === false || !isset($parts['scheme'], $parts['host'])) {
+            return '';
+        }
+        $origin = $parts['scheme'] . '://' . $parts['host'];
+        if (isset($parts['port'])) {
+            $origin .= ':' . (string)$parts['port'];
+        }
+        return $origin;
+    }
+
+    /**
      * @throws Exception
      */
     public function generateInviteUrl(): string
@@ -51,50 +71,66 @@ final class Invite
             'redirect_uri',
         ]);
 
-        $auth     = $this->getAuthLib()->getAuthfromCookies();
-        $authArr  = $auth->toArray();
-        $cookie   = $authArr['authCookie'] ?? null;
+        $auth    = $this->getAuthLib()->getAuthfromCookies();
+        $authArr = $auth->toArray();
+        /** @var array<string,mixed>|null $cookie */
+        $cookie  = isset($authArr['authCookie']) && is_array($authArr['authCookie'])
+            ? $authArr['authCookie']
+            : null;
 
-        if (empty($cookie)) {
+        if ($cookie === null) {
             throw new Exception('User not logged in');
         }
-
-        if (empty($cookie['sub'])) {
+        $inviterSub = isset($cookie['sub']) ? (string)$cookie['sub'] : '';
+        if ($inviterSub === '') {
             throw new Exception('User cookie missing');
         }
 
-        $redirectURI = $this->config->getRedirectURI();
-        $parts = parse_url($redirectURI);
+        // Choose redirect URI: request param overrides config if present
+        $redirectURIParam = isset($params['redirect_uri']) ? (string)$params['redirect_uri'] : null;
+        $redirectURIConf  = $this->config->getRedirectURI(); // ?string
+        $redirectURI      = $redirectURIParam !== null && $redirectURIParam !== ''
+            ? $redirectURIParam
+            : ($redirectURIConf ?? '');
 
-        // Build origin (scheme + host + optional port)
-        $origin = $parts['scheme'] . '://' . $parts['host'];
-        if (!empty($parts['port'])) {
-            $origin .= ':' . $parts['port'];
-        }
+        $origin = $this->buildOrigin($redirectURI);
+        $defaultTargetURI = ($origin !== '' ? $origin . '/' : '/');
 
-        // Add trailing slash
-        $defaultTargetURI = $origin . '/';
+        // Ensure strings for sprintf()
+        $inviterName = isset($cookie['name']) && is_string($cookie['name'])
+            ? $cookie['name']
+            : (isset($authArr['name']) && is_string($authArr['name']) ? $authArr['name'] : 'Someone');
 
-        // Safely pull inviter name and app name
-        $inviterName = $cookie['name'] ?? $authArr['name'] ?? 'Someone';
-        $appName     = $params['app_name'] ?? 'your app';
+        $appName = isset($params['app_name']) ? (string)$params['app_name'] : 'your app';
 
-        // Default prompt if none provided
-        $defaultPrompt = sprintf('%s has invited you to join %s', $inviterName, $appName);
+        $defaultPrompt = sprintf(
+            '%s has invited you to join %s',
+            (string)$inviterName,
+            (string)$appName
+        );
 
         $request = [
-            'app_name'           => $params['app_name'] ?? null,
-            'prompt'             => $params['prompt'] ?? $defaultPrompt,
-            'role'               => $params['role'] ?? null,
-            'tenant'             => $params['tenant'] ?? null,
-            'state'              => $params['state'] ?? null,
-            'inviter'            => $cookie['sub'], // TODO: expose via a getter on AuthLib if preferred
-            'client_id'          => $this->config->getClientId(),
-            'initiate_login_uri' => $this->config->getRedirectURI() ?? '/', // TODO: confirm correct source
-            'return_uri'         => $params['target_uri'] ?? $defaultTargetURI,
+            'app_name'           => isset($params['app_name']) ? (string)$params['app_name'] : null,
+            'prompt'             => isset($params['prompt']) ? (string)$params['prompt'] : $defaultPrompt,
+            'role'               => isset($params['role']) ? (string)$params['role'] : null,
+            'tenant'             => isset($params['tenant']) ? (string)$params['tenant'] : null,
+            'state'              => isset($params['state']) ? (string)$params['state'] : null,
+            'inviter'            => $inviterSub,
+            'client_id'          => (string)$this->config->getClientId(),
+            'initiate_login_uri' => $redirectURI !== '' ? $redirectURI : '/',
+            'return_uri'         => isset($params['target_uri']) && $params['target_uri'] !== ''
+                ? (string)$params['target_uri']
+                : $defaultTargetURI,
         ];
 
-        $queryString = http_build_query($request);
-        return "https://wallet.{$this->config->getHelloDomain()}/invite?" . $queryString;
+        // Remove nulls so http_build_query only serializes present fields
+        $request = array_filter(
+            $request,
+            static fn($v) => $v !== null
+        );
+
+        $queryString = http_build_query($request, '', '&', PHP_QUERY_RFC3986);
+
+        return 'https://wallet.' . (string)$this->config->getHelloDomain() . '/invite?' . $queryString;
     }
 }

--- a/src/Handler/Invite.php
+++ b/src/Handler/Invite.php
@@ -128,8 +128,9 @@ final class Invite
         $helloDomainRaw = $this->config->getHelloDomain();
         $helloDomain    = is_string($helloDomainRaw) ? $helloDomainRaw : '';
 
-        // Compute once to avoid “always true” inference
-        $targetUri = $this->strFrom($params, 'target_uri');
+        // Normalize return URI first to avoid ternary that PHPStan flags
+        $targetUri  = $this->strFrom($params, 'target_uri');
+        $returnUri  = ($targetUri === null || $targetUri === '') ? $defaultTargetURI : $targetUri;
 
         $request = [
             'app_name'           => $this->strFrom($params, 'app_name'),
@@ -140,7 +141,7 @@ final class Invite
             'inviter'            => $inviterSub,
             'client_id'          => $clientId,
             'initiate_login_uri' => $redirectURI !== '' ? $redirectURI : '/',
-            'return_uri'         => ($targetUri !== null && $targetUri !== '') ? $targetUri : $defaultTargetURI,
+            'return_uri'         => $returnUri,
         ];
 
         // Remove nulls so http_build_query only serializes present fields

--- a/src/Handler/Invite.php
+++ b/src/Handler/Invite.php
@@ -128,9 +128,11 @@ final class Invite
         $helloDomainRaw = $this->config->getHelloDomain();
         $helloDomain    = is_string($helloDomainRaw) ? $helloDomainRaw : '';
 
-        // Normalize return URI first to avoid ternary that PHPStan flags
-        $targetUri  = $this->strFrom($params, 'target_uri');
-        $returnUri  = ($targetUri === null || $targetUri === '') ? $defaultTargetURI : $targetUri;
+        $targetUri = $this->strFrom($params, 'target_uri');
+        $returnUri = $defaultTargetURI;
+        if ($targetUri !== null && $targetUri !== '') {
+            $returnUri = $targetUri;
+        }
 
         $request = [
             'app_name'           => $this->strFrom($params, 'app_name'),

--- a/src/Handler/Login.php
+++ b/src/Handler/Login.php
@@ -126,7 +126,7 @@ class Login
         $authResponse = $this->getAuthHelper()->createAuthRequest($request);
 
         /** @var string $targetUri */
-        $targetUri = $params['target_uri'];
+        $targetUri = $params['target_uri'] ?? '/';
 
         $this->getOIDCManager()->saveOidc(OIDC::fromArray([
             'nonce' => $authResponse['nonce'],

--- a/src/HelloClient.php
+++ b/src/HelloClient.php
@@ -6,6 +6,7 @@ use Exception;
 use HelloCoop\Exception\CallbackException;
 use HelloCoop\Exception\CryptoFailedException;
 use HelloCoop\Exception\InvalidSecretException;
+use HelloCoop\Exception\SameSiteCallbackException;
 use HelloCoop\HelloRequest\HelloRequest;
 use HelloCoop\HelloRequest\HelloRequestInterface;
 use HelloCoop\HelloResponse\HelloResponse;

--- a/src/HelloClient.php
+++ b/src/HelloClient.php
@@ -106,7 +106,18 @@ class HelloClient
      */
     public function getAuth(): array
     {
-        return$this->getAuthHandler()->handleAuth()->toArray();
+        $auth = $this->getAuthHandler()->handleAuth()->toArray();
+        if ($auth['isLoggedIn'] && isset($auth['authCookie'])) {
+            return [
+                'isLoggedIn' => true,
+                'email' => $auth['authCookie']['email'],
+                'email_verified' => $auth['authCookie']['email_verified'],
+                'name' => $auth['authCookie']['name'],
+                'picture' => $auth['authCookie']['picture'],
+                'sub' => $auth['authCookie']['sub'],
+            ];
+        }
+        return ['isLoggedIn' => $auth['isLoggedIn']];
     }
 
     /**
@@ -152,7 +163,7 @@ class HelloClient
         $this->helloResponse->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
         $this->helloResponse->setHeader('Pragma', 'no-cache');
         $this->helloResponse->setHeader('Expires', '0');
-        return $this->helloResponse->json($this->getAuthHandler()->handleAuth()->toArray());
+        return $this->helloResponse->json($this->getAuth());
     }
 
     /**

--- a/src/HelloClient.php
+++ b/src/HelloClient.php
@@ -3,23 +3,22 @@
 namespace HelloCoop;
 
 use Exception;
+use HelloCoop\Exception\CallbackException;
 use HelloCoop\Exception\CryptoFailedException;
 use HelloCoop\Exception\InvalidSecretException;
-use HelloCoop\HelloRequest\HelloRequestInterface;
 use HelloCoop\HelloRequest\HelloRequest;
-use HelloCoop\HelloResponse\HelloResponseInterface;
+use HelloCoop\HelloRequest\HelloRequestInterface;
 use HelloCoop\HelloResponse\HelloResponse;
-use HelloCoop\Renderers\PageRendererInterface;
+use HelloCoop\HelloResponse\HelloResponseInterface;
 use HelloCoop\Renderers\DefaultPageRenderer;
+use HelloCoop\Renderers\PageRendererInterface;
 use HelloCoop\Config\ConfigInterface;
 use HelloCoop\Handler\Auth;
 use HelloCoop\Handler\Invite;
-use HelloCoop\Handler\Logout;
 use HelloCoop\Handler\Login;
+use HelloCoop\Handler\Logout;
 use HelloCoop\Handler\Callback;
 use HelloCoop\Handler\Command;
-use HelloCoop\Exception\CallbackException;
-use HelloCoop\Exception\SameSiteCallbackException;
 
 final class HelloClient
 {
@@ -46,9 +45,8 @@ final class HelloClient
         $this->helloResponse = $helloResponse ?? new HelloResponse();
         $this->pageRenderer  = $pageRenderer  ?? new DefaultPageRenderer();
 
-        $domainRaw = $this->config->getHelloDomain();
-        $domain    = is_string($domainRaw) ? $domainRaw : '';
-        $this->issuer = 'https://issuer.' . $domain;
+        // getHelloDomain() is typed as string by PHPStan, so no ternary/guards needed
+        $this->issuer = 'https://issuer.' . $this->config->getHelloDomain();
     }
 
     private function getCallbackHandler(): Callback

--- a/src/HelloResponse/HelloResponseInterface.php
+++ b/src/HelloResponse/HelloResponseInterface.php
@@ -83,9 +83,9 @@ interface HelloResponseInterface
      * for encoding and returning JSON data.
      *
      * @param array<string, mixed> $data The data to be converted to a JSON response.
-     * @return string The string encoded JSON response data.
+     * @return mixed
      */
-    public function json(array $data): string;
+    public function json(array $data);
 
     /**
      * Renders the given content as an HTTP response.
@@ -95,7 +95,7 @@ interface HelloResponseInterface
      * depending on the framework or environment being used.
      *
      * @param string $content The content to render as a response.
-     * @return string The rendered response content.
+     * @return mixed
      */
-    public function render(string $content): string;
+    public function render(string $content);
 }

--- a/tests/Handler/InviteTest.php
+++ b/tests/Handler/InviteTest.php
@@ -47,6 +47,7 @@ class InviteTest extends TestCase
 
     public function testCanGenerateInviteUrl(): void
     {
+
         $_GET = [
             'target_uri' => 'https://example.com',
             'app_name' => 'MyApp',
@@ -64,7 +65,7 @@ class InviteTest extends TestCase
 
         $url = $this->invite->generateInviteUrl();
 
-        $expectedUrl = "https://wallet.hello.coop/invite?app_name=MyApp&prompt=Login&role=Admin&tenant=Tenant123&state=state456&inviter=user123&client_id=valid_client_id&initiate_login_uri=https%2F%2Fmy-domain&return_uri=https%3A%2F%2Fexample.com";
+        $expectedUrl = "https://wallet.hello.coop/invite?app_name=MyApp&prompt=Login&role=Admin&tenant=Tenant123&state=state456&inviter=user123&client_id=valid_client_id&initiate_login_uri=https%3A%2F%2Fmy-domain&return_uri=https%3A%2F%2Fexample.com";
 
         $this->assertSame($expectedUrl, $url);
     }

--- a/tests/Handler/InviteTest.php
+++ b/tests/Handler/InviteTest.php
@@ -65,7 +65,7 @@ class InviteTest extends TestCase
 
         $url = $this->invite->generateInviteUrl();
 
-        $expectedUrl = "https://wallet.hello.coop/invite?app_name=MyApp&prompt=Login&role=Admin&tenant=Tenant123&state=state456&inviter=user123&client_id=valid_client_id&initiate_login_uri=https%3A%2F%2Fmy-domain&return_uri=https%3A%2F%2Fexample.com";
+        $expectedUrl = "https://wallet.hello.coop/invite?app_name=MyApp&prompt=Login&role=Admin&tenant=Tenant123&state=state456&inviter=user123&client_id=valid_client_id&initiate_login_uri=%2Fredirect&return_uri=https%3A%2F%2Fexample.com";
 
         $this->assertSame($expectedUrl, $url);
     }

--- a/tests/Traits/ServiceMocksTrait.php
+++ b/tests/Traits/ServiceMocksTrait.php
@@ -53,7 +53,7 @@ trait ServiceMocksTrait
         $this->configMock->method('getClientId')
             ->willReturn('valid_client_id');
         $this->configMock->method('getRedirectURI')
-            ->willReturn('https//my-domain');
+            ->willReturn('https://my-domain');
 
         $this->configMock->method('getHelloDomain')->willReturn('hello.coop');
 


### PR DESCRIPTION
This PR updates the `HelloResponseInterface` to make it more flexible and framework-agnostic when handling responses.

#### Changes

* Changed return types of `json()` and `render()` from `string` to `mixed`
* Updated docblocks to reflect the broader return type
* Allows implementations to return framework-native response objects instead of plain strings

#### Motivation

Previously, the contract required `json()` and `render()` to return only strings, which limited usage in frameworks such as Drupal or Symfony.
With this change, implementations can now return proper response objects such as:

* **Drupal** → `JsonResponse`, `HtmlResponse`, `TrustedRedirectResponse`
* **Symfony** → `Response`, `RedirectResponse`, `JsonResponse`

This makes the interface more compatible with real-world frameworks while keeping the contract consistent.

#### Impact

* No breaking changes for existing code that returns strings
* Provides greater flexibility for new implementations