### PR TITLE
Refactor HelloResponseInterface to support framework-specific response objects

### DIFF
--- a/src/HelloResponse/HelloResponseInterface.php
+++ b/src/HelloResponse/HelloResponseInterface.php
@@ -83,9 +83,9 @@ interface HelloResponseInterface
      * for encoding and returning JSON data.
      *
      * @param array<string, mixed> $data The data to be converted to a JSON response.
-     * @return string The string encoded JSON response data.
+     * @return mixed
      */
-    public function json(array $data): string;
+    public function json(array $data);
 
     /**
      * Renders the given content as an HTTP response.
@@ -95,7 +95,7 @@ interface HelloResponseInterface
      * depending on the framework or environment being used.
      *
      * @param string $content The content to render as a response.
-     * @return string The rendered response content.
+     * @return mixed
      */
-    public function render(string $content): string;
+    public function render(string $content);
 }


### PR DESCRIPTION
This PR updates the `HelloResponseInterface` to make it more flexible and framework-agnostic when handling responses.

#### Changes

* Changed return types of `json()` and `render()` from `string` to `mixed`
* Updated docblocks to reflect the broader return type
* Allows implementations to return framework-native response objects instead of plain strings

#### Motivation

Previously, the contract required `json()` and `render()` to return only strings, which limited usage in frameworks such as Drupal or Symfony.
With this change, implementations can now return proper response objects such as:

* **Drupal** → `JsonResponse`, `HtmlResponse`, `TrustedRedirectResponse`
* **Symfony** → `Response`, `RedirectResponse`, `JsonResponse`

This makes the interface more compatible with real-world frameworks while keeping the contract consistent.

#### Impact

* No breaking changes for existing code that returns strings
* Provides greater flexibility for new implementations